### PR TITLE
chore: enable Dependabot for actions + Renovate for everything else

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    groups:
+      github-actions:
+        patterns:
+          - "*"

--- a/package.json
+++ b/package.json
@@ -16,7 +16,6 @@
   "keywords": [
     "ai-agent",
     "agent-skill",
-    "ai-agent-skill",
     "skill-coordinator",
     "anthropic",
     "claude-code",

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:recommended"
+  ]
+}

--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,8 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:recommended"
-  ]
+  ],
+  "github-actions": {
+    "enabled": false
+  }
 }


### PR DESCRIPTION
## Summary
- `.github/dependabot.yml` — weekly grouped github-actions updates (matches composer-agent-skill-plugin precedent).
- `renovate.json` — `config:recommended` for everything else (npm devDeps, etc.).
- Drop `ai-agent-skill` keyword from the coordinator's own `package.json`. The keyword is the convention-based opt-in marker for *skill* packages; carrying it on the coordinator caused every install to emit `SKILL.md not found at 'SKILL.md'` against itself. Caught during a real-world install test against `@netresearch/git-workflow-skill`.

SECURITY.md and CODEOWNERS continue to come from the netresearch/.github org-default repo, also matching the sibling repo.

## Test plan
- [x] CI green on the new branch (Node 20/22/24 + lint)
- [x] dependabot.yml parses (no schema errors)
- [x] renovate.json valid against renovate schema
- [x] Manual install of coordinator + git-workflow-skill in a tmpdir produces a clean AGENTS.md and no spurious warnings against the coordinator itself