### PR TITLE
chore(release): v0.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.2] - 2026-05-02
+
+### Fixed
+
+- Drop `ai-agent-skill` keyword from the coordinator's own `package.json`. The keyword is the convention-based opt-in marker for *skill* packages; carrying it on the coordinator caused every install to emit `SKILL.md not found at 'SKILL.md'` against itself when run alongside any real skill package. Caught during a real-world install test against `@netresearch/git-workflow-skill`.
+
+### Added
+
+- `.github/dependabot.yml` for weekly grouped github-actions updates and `renovate.json` (`config:recommended`, github-actions disabled) for the rest of the dependency surface — mirrors the `composer-agent-skill-plugin` sibling setup.
+
+### Changed
+
+- Release workflow's idempotency check now probes `https://registry.npmjs.org/` directly via `curl` instead of `npm view`, so the skip works correctly under the runner's OIDC auth context (`npm view` was returning 404 when the published version actually existed).
+
+### Hardened
+
+- Default branch now protected by a Repository Ruleset: required status checks (Lint, Node 20/22/24), no force pushes, no deletion, required linear history, required review-thread resolution, automatic Copilot code review.
+- Default workflow permissions reduced from `write` to `read`; jobs that need write declare it explicitly.
+- `.npmrc` added to `.gitignore` so a manual local publish workflow can never accidentally commit a token.
+
 ## [0.1.1] - 2026-05-02
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@netresearch/agent-skill-coordinator",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Node coordinator that discovers AI agent skills from installed npm packages and registers them in AGENTS.md. Sibling of netresearch/composer-agent-skill-plugin.",
   "type": "module",
   "license": "MIT",


### PR DESCRIPTION
## Summary
Patch release. The keyword-on-coordinator fix from #2 needs an actual published version to reach users, so this PR bumps package.json to 0.1.2 and cuts CHANGELOG.md.

## What v0.1.2 fixes / adds (since v0.1.1 on npm)
- fix(pkg): drop `ai-agent-skill` keyword from the coordinator's own package.json (was triggering a self-detection warning on every install)
- chore: Dependabot for github-actions + Renovate for everything else
- ci: idempotency check uses curl against the registry REST endpoint instead of `npm view` (which 404s under the runner's OIDC auth context)
- security: default branch ruleset (required status checks, no force-push, no deletion, required linear history, required thread resolution, Copilot auto-review)
- security: default workflow permissions changed from write to read
- security: `.npmrc` added to `.gitignore`

## Release flow
After merge, `git tag -s v0.1.2 -m "v0.1.2" && git push origin v0.1.2`. The release workflow publishes to npm via OIDC Trusted Publishing (configured by maintainer after v0.1.1) and creates the GitHub Release.