### PR TITLE
fix: sync package-lock.json version to 0.1.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@netresearch/agent-skill-coordinator",
-  "version": "0.1.0",
+  "version": "0.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@netresearch/agent-skill-coordinator",
-      "version": "0.1.0",
+      "version": "0.1.2",
       "hasInstallScript": true,
       "license": "MIT",
       "bin": {


### PR DESCRIPTION
## Summary

The lockfile root version remained at `0.1.0` after the v0.1.2 bump in #4 — `npm install` and lockfile-aware tooling reported a mismatched root package version.

## Why no v0.1.3 release

`package-lock.json` is **not** in the published npm tarball (verified against `dist.tarball` for v0.1.2 — the `files` allowlist only includes `src/ bin/ LICENSE README.md CHANGELOG.md`). This bug only affects the repo checkout, CI installs, and contributors — npm consumers are unaffected, so no version bump is needed.

## Addresses

Resolves copilot-pull-request-reviewer feedback on #4 (https://github.com/netresearch/node-agent-skill-coordinator/pull/4#discussion_r-PRRT_kwDOSR_Z7c5_GziH).

## Test plan

- [x] `npm install --package-lock-only` regenerates clean
- [ ] CI Lint + Node 20/22/24 pass on this PR
- [ ] Confirm `npm ci` no longer warns about version mismatch