### PR TITLE
chore(release): v0.1.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.3] - 2026-06-09
+
+### Fixed
+
+- Sync `package-lock.json` version to match `package.json`.
+
 ## [0.1.2] - 2026-05-02
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@netresearch/agent-skill-coordinator",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@netresearch/agent-skill-coordinator",
-      "version": "0.1.2",
+      "version": "0.1.3",
       "hasInstallScript": true,
       "license": "MIT",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@netresearch/agent-skill-coordinator",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Node coordinator that discovers AI agent skills from installed npm packages and registers them in AGENTS.md. Sibling of netresearch/composer-agent-skill-plugin.",
   "type": "module",
   "license": "MIT",


### PR DESCRIPTION
Patch release v0.1.3.

## Changes

- Bump version to `0.1.3` in `package.json` and `package-lock.json` (both `.version` and `.packages[""].version`).
- CHANGELOG: promote Unreleased to `## [0.1.3] - 2026-06-09` with a `### Fixed` entry.

### Fixed

- Sync `package-lock.json` version to match `package.json`.

CI publishes to npm on the `v0.1.3` tag push after merge.
