### PR TITLE
ci: add OpenSSF Scorecard supply-chain scan

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,23 @@
+name: OpenSSF Scorecard
+
+# Supply-chain posture scoring (branch protection, pinned actions, token
+# permissions, …). Runs on default-branch push and on a weekly schedule;
+# results upload to the code-scanning dashboard.
+
+on:
+  push:
+    branches: [main, master]
+  schedule:
+    - cron: '0 0 * * 0'
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  scorecard:
+    uses: netresearch/.github/.github/workflows/scorecard.yml@main
+    permissions:
+      contents: read
+      security-events: write
+      id-token: write
+      actions: read


### PR DESCRIPTION
Adds the standard netresearch OpenSSF Scorecard workflow for parity with the other node repos. Explicit per-job permissions under top-level `permissions: {}`; results upload to the code-scanning dashboard. Non-blocking (Scorecard reports a score, it does not fail the build). CodeQL default-setup and the existing `ci.yml` are unchanged.