### PR TITLE
chore(ci): adopt node-ci gold-standard reusable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,61 +4,30 @@ on:
   push:
     branches: [main]
   pull_request:
-    branches: [main]
-  workflow_dispatch:
 
-permissions:
-  contents: read
+permissions: {}
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
-  tests:
-    name: Node ${{ matrix.node }}
-    runs-on: ubuntu-latest
-
-    strategy:
-      fail-fast: false
-      matrix:
-        node: ['20', '22', '24']
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-
-      - name: Setup Node.js ${{ matrix.node }}
-        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
-        with:
-          node-version: ${{ matrix.node }}
-
-      - name: Setup Bun
-        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
-
-      - name: Install dev dependencies
-        # --ignore-scripts: don't run our own postinstall (it would scan the
-        # repo's empty node_modules and is not what CI is testing). Also blocks
-        # postinstall on incoming dev deps, which we have no reason to trust.
-        run: bun install --frozen-lockfile --ignore-scripts
-
-      - name: Run tests
-        run: bun run test
-
-  lint:
-    name: Lint
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-
-      - name: Setup Node.js
-        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
-        with:
-          node-version: '24'
-
-      - name: Setup Bun
-        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
-
-      - name: Install dev dependencies
-        run: bun install --frozen-lockfile --ignore-scripts
-
-      - name: Run ESLint
-        run: bun run lint
+  # CI via the org node gold-standard reusable. Plain-ESM package: no
+  # type-check/build layer, no GITLEAKS_LICENSE, so those are opted out.
+  # Adoption adds CodeQL + node-audit + dependency-review the repo lacked.
+  ci:
+    uses: netresearch/.github/.github/workflows/node-ci.yml@main
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+      pull-requests: write
+    with:
+      package-manager: bun
+      test-matrix: '["20", "22", "24"]'
+      install-cmd: "bun install --frozen-lockfile --ignore-scripts"
+      test-cmd: "bun run test"
+      enable-type-check: false
+      enable-build: false
+      enable-format-check: false
+      enable-gitleaks: false

--- a/bun.lock
+++ b/bun.lock
@@ -11,6 +11,9 @@
       },
     },
   },
+  "overrides": {
+    "brace-expansion": ">=5.0.6",
+  },
   "packages": {
     "@eslint-community/eslint-utils": ["@eslint-community/eslint-utils@4.9.1", "", { "dependencies": { "eslint-visitor-keys": "^3.4.3" }, "peerDependencies": { "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0" } }, "sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ=="],
 
@@ -52,7 +55,7 @@
 
     "balanced-match": ["balanced-match@4.0.4", "", {}, "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA=="],
 
-    "brace-expansion": ["brace-expansion@5.0.5", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ=="],
+    "brace-expansion": ["brace-expansion@5.0.7", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA=="],
 
     "cross-spawn": ["cross-spawn@7.0.6", "", { "dependencies": { "path-key": "^3.1.0", "shebang-command": "^2.0.0", "which": "^2.0.1" } }, "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA=="],
 

--- a/package.json
+++ b/package.json
@@ -49,5 +49,8 @@
   ],
   "engines": {
     "node": ">=20.0.0"
+  },
+  "overrides": {
+    "brace-expansion": ">=5.0.6"
   }
 }


### PR DESCRIPTION
Adopts the org node-ci gold standard. Plain-ESM package: type-check/build/format/gitleaks opted out via the new node-ci toggles; adds CodeQL + node-audit + dependency-review the repo lacked. Preserves the Node 20/22/24 test matrix and --ignore-scripts.