### PR TITLE
ci: publish via the shared node-release reusable

### DIFF
--- a/.github/workflows/release.when-tagged.yml
+++ b/.github/workflows/release.when-tagged.yml
@@ -2,16 +2,27 @@
 # when a signed tag is pushed.
 #
 # Trigger: git tag -s vX.Y.Z -m "vX.Y.Z" && git push origin vX.Y.Z
-# Also available via workflow_dispatch for manual reruns on existing tags.
+# Also available via workflow_dispatch for manual reruns on existing tags —
+# select the vX.Y.Z TAG as the run ref, not a branch: version-source
+# manifest-verified needs a tag ref and fails with a clear message otherwise.
 #
-# npm authentication: OIDC Trusted Publishing — NO token required.
-# One-time setup on npmjs.com → @netresearch → Trusted Publishers:
-#   Publisher:        GitHub Actions
-#   Repository owner: netresearch
-#   Repository name:  node-agent-skill-coordinator
-#   Workflow:         release.when-tagged.yml
-#   Package name:     @netresearch/agent-skill-coordinator
-# (This can be configured before the package's first publish.)
+# Thin caller of the shared node-release reusable: build, npm publish (OIDC
+# Trusted Publishing, no token), the GitHub Packages pass, and the GitHub
+# Release all live in netresearch/.github, so the pinned action versions and
+# the publish logic are maintained centrally. This file has zero step-level
+# `uses:`.
+#
+# THE FILENAME MUST STAY release.when-tagged.yml. npm Trusted Publishing
+# validates the CALLER workflow's filename, not the reusable that runs
+# `npm publish`, so the Trusted Publisher configured on npmjs.com
+# (@netresearch -> node-agent-skill-coordinator -> Workflow:
+# release.when-tagged.yml) keeps matching only while this filename is
+# unchanged. Editing the contents to call the reusable is fine; renaming is not.
+#
+# The release-time `bun run test` + `bun run lint` gate is intentionally not
+# reproduced here: main requires node-ci.yml green (a required status check)
+# and tags are cut from main, and version-source: manifest-verified still
+# hard-fails a tag that disagrees with package.json.
 
 name: Release
 
@@ -21,122 +32,22 @@ on:
     tags:
       - 'v*'
 
-permissions:
-  contents: read
+permissions: {}
 
 jobs:
-  verify:
-    name: Verify
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-
-      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
-        with:
-          node-version: '24'
-
-      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
-
-      - name: Install dev dependencies
-        run: bun install --frozen-lockfile --ignore-scripts
-
-      - name: Verify tag matches package.json version
-        if: github.event_name == 'push'
-        env:
-          REF_NAME: ${{ github.ref_name }}
-        run: |
-          TAG_VERSION="${REF_NAME#v}"
-          PKG_VERSION="$(node -p "require('./package.json').version")"
-          if [ "$TAG_VERSION" != "$PKG_VERSION" ]; then
-            echo "::error::Tag $REF_NAME (version $TAG_VERSION) does not match package.json version $PKG_VERSION"
-            exit 1
-          fi
-          echo "Tag $REF_NAME aligns with package.json version $PKG_VERSION"
-
-      - name: Run tests
-        run: bun run test
-
-      - name: Run lint
-        run: bun run lint
-
-  publish:
-    name: Publish
-    needs: verify
-    runs-on: ubuntu-latest
+  release:
+    uses: netresearch/.github/.github/workflows/node-release.yml@main
     permissions:
       contents: write
-      packages: write
       id-token: write
-    steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-
-      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
-        with:
-          node-version: '24'
-          registry-url: 'https://registry.npmjs.org'
-          scope: '@netresearch'
-
-      - name: Check whether this version is already on npm
-        id: npm_check
-        # Use a plain HTTP probe instead of `npm view` — setup-node has wired
-        # this runner up with OIDC auth for the registry, and `npm view` then
-        # sends an authed request that 404s for any package whose Trusted
-        # Publisher doesn't include this exact workflow context, even when
-        # the package and version are publicly readable. The registry's REST
-        # endpoint is unauthenticated and returns the truth.
-        run: |
-          PKG_VERSION="$(node -p "require('./package.json').version")"
-          STATUS=$(curl -s -o /dev/null -w "%{http_code}" \
-            "https://registry.npmjs.org/@netresearch/agent-skill-coordinator/${PKG_VERSION}")
-          if [ "$STATUS" = "200" ]; then
-            echo "Version ${PKG_VERSION} already on npm — skipping publish step."
-            echo "skip=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "Version ${PKG_VERSION} not on npm yet (HTTP $STATUS) — will publish."
-            echo "skip=false" >> "$GITHUB_OUTPUT"
-          fi
-
-      - name: Publish to npm (OIDC + provenance)
-        if: steps.npm_check.outputs.skip == 'false'
-        run: npm publish --access=public --provenance
-
-      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
-        with:
-          node-version: '24'
-          registry-url: 'https://npm.pkg.github.com'
-          scope: '@netresearch'
-
-      - name: Check whether this version is already on GitHub Package Registry
-        id: ghcr_check
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          PKG_VERSION="$(node -p "require('./package.json').version")"
-          # GHCR's npm-compatible API requires auth even for HEAD/GET on
-          # private namespaces, so keep using `npm view` here — it works
-          # because GHCR doesn't have the same OIDC quirk as registry.npmjs.org.
-          if npm view "@netresearch/agent-skill-coordinator@${PKG_VERSION}" version --registry=https://npm.pkg.github.com >/dev/null 2>&1; then
-            echo "Version ${PKG_VERSION} already on GitHub Package Registry — skipping publish step."
-            echo "skip=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "Version ${PKG_VERSION} not on GHCR yet — will publish."
-            echo "skip=false" >> "$GITHUB_OUTPUT"
-          fi
-
-      - name: Publish to GitHub Package Registry
-        if: steps.ghcr_check.outputs.skip == 'false'
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: npm publish --access=public
-
-      - name: Create GitHub Release
-        if: github.event_name == 'push'
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          TAG: ${{ github.ref_name }}
-        run: |
-          if gh release view "$TAG" >/dev/null 2>&1; then
-            echo "Release $TAG already exists — skipping."
-          else
-            gh release create "$TAG" --generate-notes
-          fi
+      packages: write
+    with:
+      package-manager: bun
+      install-cmd: bun install --frozen-lockfile --ignore-scripts
+      version-source: manifest-verified
+      publish-npm: true
+      npm-access: public
+      provenance: true
+      publish-github-packages: true
+      skip-if-published: true
+      create-github-release: true


### PR DESCRIPTION
Turns `release.when-tagged.yml` into a thin caller of the shared [`node-release.yml`](https://github.com/netresearch/.github/blob/main/.github/workflows/node-release.yml) reusable ([netresearch/.github#301](https://github.com/netresearch/.github/pull/301)), removing every step-level third-party action from this release workflow.

### Behaviour preserved

| | before | after |
|---|---|---|
| npm publish | OIDC + provenance | `publish-npm` + `provenance: true` |
| GitHub Packages | second `npm publish` | `publish-github-packages: true` |
| GitHub Release | `gh release create --generate-notes` | `create-github-release: true` |
| tag vs manifest | (varies) | `version-source: manifest-verified` — hard-fails a mis-tag |
| husky suppression | `HUSKY=0` | `install --ignore-scripts` |

### The filename is deliberately unchanged

npm Trusted Publishing validates the **calling** workflow's filename, not the reusable that runs `npm publish` ([npm docs](https://docs.npmjs.com/trusted-publishers)). The Trusted Publisher for `@netresearch/agent-skill-coordinator` is bound to `release.when-tagged.yml`, so this PR edits the file **in place** and keeps its name — Trusted Publishing keeps matching.

### One thing to know before the first release after merge

- **This PR publishes nothing** — publishing only fires on the next real version tag.
- Confirm on npmjs.com that the Trusted Publisher for `@netresearch/agent-skill-coordinator` still lists workflow `release.when-tagged.yml` (it should — the filename is unchanged). This is the one thing that can't be checked from the repo.
- A `workflow_dispatch` rerun must select the **tag** as the ref (not a branch): `manifest-verified` needs a tag ref and fails with a clear message otherwise.

The release-time `test` + `lint` gate is not reproduced here — `main` requires CI green (a required status check) and tags are cut from `main`.